### PR TITLE
[codex] 診療報酬掲示の配置を整理

### DIFF
--- a/next/src/app/consultation/Message02.tsx
+++ b/next/src/app/consultation/Message02.tsx
@@ -1,11 +1,35 @@
-import { Box, Typography } from "@mui/material";
+import { Box, List, ListItem, Typography } from "@mui/material";
 
 export default function Message01() {
   return (
     <Box sx={{ maxWidth: 800, mx: "auto" }}>
-      <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
+      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 3 }}>
         かかりつけ医として、ご納得いただくまで対応いたします。ご質問にもお答えいたします。
       </Typography>
+
+      <Typography variant="h6" sx={{ fontWeight: "bold", color: "#1a1a1a", mb: 1 }}>
+        生活習慣病管理料について
+      </Typography>
+      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1 }}>
+        高血圧症、脂質異常症、糖尿病の患者様について、療養計画書を作成し、総合的な治療管理を行っております。
+      </Typography>
+      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1 }}>
+        患者様の状態に応じ、以下について継続的に管理を行います。
+      </Typography>
+      <List sx={{ listStyleType: "disc", pl: 4, py: 0 }}>
+        {[
+          "血圧",
+          "体重",
+          "食事",
+          "運動",
+          "喫煙",
+          "服薬状況",
+        ].map((item) => (
+          <ListItem key={item} sx={{ display: "list-item", py: 0.3, lineHeight: 1.8 }}>
+            {item}
+          </ListItem>
+        ))}
+      </List>
     </Box>
   );
 }

--- a/next/src/app/description/Message02.tsx
+++ b/next/src/app/description/Message02.tsx
@@ -1,22 +1,177 @@
-import { Box, List, ListItem, Typography } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  List,
+  ListItem,
+  Typography,
+} from "@mui/material";
 
-export default function Message01() {
+const noticeItems = [
+  {
+    title: "医療DX推進体制整備加算について",
+    paragraphs: [
+      "当院では、質の高い診療を実施するため、医療DXを推進し、以下の体制を整備しております。",
+    ],
+    bullets: [
+      "オンライン資格確認等システムにより取得した診療情報等を活用して診療を実施しています。",
+      "マイナ保険証の利用を促進しております。",
+      "電子処方箋の発行体制を整備しています。",
+      "電子カルテ情報共有サービスを活用できる体制について整備を進めています。",
+      "医療DX推進体制整備加算を算定しております。",
+    ],
+  },
+  {
+    title: "医療情報取得加算について",
+    paragraphs: [
+      "当院ではオンライン資格確認を行う体制を有しており、患者様の受診歴、薬剤情報、特定健診情報その他必要な診療情報を取得・活用して診療を行っております。",
+    ],
+  },
+  {
+    title: "明細書発行体制等加算について",
+    paragraphs: [
+      "当院では医療の透明化および患者様への情報提供を推進する観点から、領収書発行の際に個別の診療報酬算定項目が分かる明細書を無料で発行しております。",
+      "明細書の発行を希望されない場合は、受付までお申し出ください。",
+    ],
+  },
+  {
+    title: "外来感染対策向上加算について",
+    paragraphs: ["当院では院内感染防止対策として、以下の取り組みを実施しております。"],
+    bullets: [
+      "感染管理者を配置しています。",
+      "標準感染予防策に基づいた院内感染対策を実施しています。",
+      "感染対策マニュアルを整備しています。",
+      "定期的に感染対策研修を実施しています。",
+      "発熱患者様等の動線分離を行っています。",
+      "地域の医療機関・医師会と感染対策連携を行っています。",
+    ],
+  },
+  {
+    title: "発熱患者等対応加算について",
+    paragraphs: [
+      "当院では、受診歴の有無にかかわらず、発熱その他感染症を疑わせる症状を呈する患者様の受け入れを行っております。",
+      "感染防止対策として、時間的・空間的分離を行い診療しております。",
+    ],
+  },
+  {
+    title: "時間外対応加算について",
+    paragraphs: [
+      "当院では継続的に受診されている患者様からの電話等による問い合わせに対し、診療時間外にも対応できる体制を整えております。",
+      "※時間外対応加算は、再診料を算定する患者様が対象となります。",
+    ],
+  },
+  {
+    title: "ベースアップ評価料について",
+    paragraphs: [
+      "当院では医療従事者の処遇改善を目的としてベースアップ評価料を算定しております。",
+      "これにより職員の賃上げを実施し、安心・安全な医療提供体制の維持に努めています。",
+    ],
+  },
+];
+
+export default function MedicalFeeNoticeMessage() {
   return (
-    <Box sx={{ maxWidth: 800, mx: "auto" }}>
-      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1 }}>
-        患者の皆様へ
-      </Typography>
-      <List sx={{ listStyleType: "disc", pl: 4 }}>
-        <ListItem sx={{ display: "list-item", py: 0.5 }}>
-          当院はマイナンバーカードによるオンライン資格確認を行なっています。
-        </ListItem>
-        <ListItem sx={{ display: "list-item", py: 0.5 }}>
-          オンライン資格確認により診療情報を取得・活用し、質の高い医療の提供に努めています
-        </ListItem>
-        <ListItem sx={{ display: "list-item", py: 0.5 }}>
-          正確な情報を取得するために・活用するために、マイナ保険証の利用にご協力をお願い致します。
-        </ListItem>
-      </List>
+    <Box sx={{ maxWidth: 960, mx: "auto" }}>
+      <Box sx={{ mb: { xs: 3, sm: 4 } }}>
+        <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1, fontWeight: 600 }}>
+          患者の皆様へ
+        </Typography>
+        <List sx={{ listStyleType: "disc", pl: 3, py: 0 }}>
+          <ListItem sx={{ display: "list-item", py: 0.35, lineHeight: 1.8 }}>
+            当院はマイナンバーカードによるオンライン資格確認を行なっています。
+          </ListItem>
+          <ListItem sx={{ display: "list-item", py: 0.35, lineHeight: 1.8 }}>
+            オンライン資格確認により診療情報を取得・活用し、質の高い医療の提供に努めています
+          </ListItem>
+          <ListItem sx={{ display: "list-item", py: 0.35, lineHeight: 1.8 }}>
+            正確な情報を取得するために・活用するために、マイナ保険証の利用にご協力をお願い致します。
+          </ListItem>
+        </List>
+      </Box>
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
+          gap: { xs: 2, sm: 2.5 },
+        }}
+      >
+        {noticeItems.map((item) => (
+          <Accordion
+            key={item.title}
+            disableGutters
+            elevation={0}
+            sx={{
+              "&:before": { display: "none" },
+              alignSelf: "start",
+              overflow: "hidden",
+              border: "1px solid #dfe9e5",
+              borderTop: "4px solid #2a7d8f",
+              borderRadius: 2,
+              bgcolor: "#fff",
+              boxShadow: "0 8px 20px rgba(42, 125, 143, 0.08)",
+              minWidth: 0,
+            }}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon sx={{ color: "#2a7d8f" }} />}
+              sx={{
+                minHeight: 72,
+                px: { xs: 2, sm: 2.5 },
+                py: 1,
+                "& .MuiAccordionSummary-content": {
+                  my: 1,
+                  minWidth: 0,
+                },
+              }}
+            >
+              <Typography
+                variant="h6"
+                sx={{
+                  fontSize: { xs: "1rem", sm: "1.05rem" },
+                  fontWeight: "bold",
+                  color: "#1a1a1a",
+                  lineHeight: 1.55,
+                }}
+              >
+                {item.title}
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ px: { xs: 2, sm: 2.5 }, pt: 0, pb: { xs: 2, sm: 2.5 } }}>
+              {item.paragraphs.map((paragraph) => (
+                <Typography
+                  key={paragraph}
+                  variant="body2"
+                  sx={{ color: "text.secondary", lineHeight: 1.8, mb: 1 }}
+                >
+                  {paragraph}
+                </Typography>
+              ))}
+              {item.bullets && (
+                <List sx={{ listStyleType: "disc", pl: 3, py: 0, mt: 0.5 }}>
+                  {item.bullets.map((bullet) => (
+                    <ListItem
+                      key={bullet}
+                      sx={{
+                        display: "list-item",
+                        color: "text.secondary",
+                        fontSize: "0.875rem",
+                        lineHeight: 1.75,
+                        py: 0.2,
+                        pl: 0,
+                      }}
+                    >
+                      {bullet}
+                    </ListItem>
+                  ))}
+                </List>
+              )}
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </Box>
     </Box>
   );
 }

--- a/next/src/app/description/Message05.tsx
+++ b/next/src/app/description/Message05.tsx
@@ -6,7 +6,7 @@ export default function Message01() {
       <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1 }}>
         当院では、「かかりつけ医」機能を有する診療所として機能強化加算を算定しております。
       </Typography>
-      <List sx={{ listStyleType: "disc", pl: 4 }}>
+      <List sx={{ listStyleType: "disc", pl: 4, mb: 4 }}>
         <ListItem sx={{ display: "list-item", py: 0.5 }}>
           健康診断の結果などの健康管理に係る相談に応じます。
         </ListItem>
@@ -20,6 +20,27 @@ export default function Message01() {
           必要に応じて、専門医・専門医療機関を紹介します。
         </ListItem>
       </List>
+
+      <Typography variant="h6" sx={{ fontWeight: "bold", color: "#1a1a1a", mb: 1 }}>
+        地域包括診療加算・地域包括診療料について
+      </Typography>
+      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1 }}>
+        当院では健康相談および予防接種に関する相談を実施しております。
+      </Typography>
+      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1 }}>
+        また、患者様の状態に応じて、以下に対応しております。
+      </Typography>
+      <List sx={{ listStyleType: "disc", pl: 4, py: 0, mb: 1 }}>
+        <ListItem sx={{ display: "list-item", py: 0.3, lineHeight: 1.8 }}>
+          28日以上の長期投薬
+        </ListItem>
+        <ListItem sx={{ display: "list-item", py: 0.3, lineHeight: 1.8 }}>
+          リフィル処方箋交付
+        </ListItem>
+      </List>
+      <Typography variant="body1" sx={{ lineHeight: 1.8 }}>
+        介護保険制度の利用に関する相談にも対応しております。
+      </Typography>
     </Box>
   );
 }

--- a/next/src/app/home-medical-care/Message01.tsx
+++ b/next/src/app/home-medical-care/Message01.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Box, List, ListItem, Typography } from "@mui/material";
 
 export default function Message02() {
   return (
@@ -12,6 +12,37 @@ export default function Message02() {
         多くの人に受け入れられるようになってきました。在宅医療は、医師をはじめ、歯科医師、
         訪問看護師、薬剤師、栄養士、理学療法士、ケアマネジャー、ホームヘルパーなど多くの方々が
         連携して定期的に患者さんのご自宅などを訪問し、チームとなって患者さんの治療やケアを24時間対応で行っていく医療活動です。
+      </Typography>
+
+      <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a", mb: 1.5 }}>
+        当院の在宅医療について
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 1, ml: 2, lineHeight: 1.8 }}>
+        当院では在宅療養支援診療所として、訪問診療を実施しております。
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 1, ml: 2, lineHeight: 1.8 }}>
+        病状に応じて、以下を行い、24時間対応体制を整えております。
+      </Typography>
+      <List sx={{ listStyleType: "disc", pl: 6, mb: 4, py: 0 }}>
+        <ListItem sx={{ display: "list-item", py: 0.3, lineHeight: 1.8 }}>
+          緊急往診
+        </ListItem>
+        <ListItem sx={{ display: "list-item", py: 0.3, lineHeight: 1.8 }}>
+          在宅看取り
+        </ListItem>
+        <ListItem sx={{ display: "list-item", py: 0.3, lineHeight: 1.8 }}>
+          訪問看護ステーションとの連携
+        </ListItem>
+      </List>
+
+      <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a", mb: 1.5 }}>
+        在宅医療DX情報活用加算について
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 1, ml: 2, lineHeight: 1.8 }}>
+        当院では居宅同意取得型のオンライン資格確認システムを活用し、取得した診療情報を計画的な医学管理のもと訪問診療に活用しています。
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 4, ml: 2, lineHeight: 1.8 }}>
+        また、マイナ保険証利用促進等、医療DXを通じて質の高い医療の提供に努めています。
       </Typography>
 
       <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a", mb: 1.5 }}>

--- a/next/src/app/online/Message02.tsx
+++ b/next/src/app/online/Message02.tsx
@@ -9,6 +9,17 @@ export default function Message02() {
         <br />
         ご不明な点やご相談がございましたら、スタッフが丁寧にご案内いたします。
       </Typography>
+
+      <Typography variant="h6" sx={{ fontWeight: "bold", color: "#1a1a1a", mb: 1 }}>
+        情報通信機器を用いた診療について
+      </Typography>
+      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 1 }}>
+        当院では情報通信機器を用いたオンライン診療を実施しております。
+      </Typography>
+      <Typography variant="body1" sx={{ lineHeight: 1.8, mb: 3 }}>
+        なお、初診において向精神薬の処方は行っておりません。
+      </Typography>
+
       <Box sx={{ textAlign: "center", mt: 3 }}>
         <Button
           component={Link}


### PR DESCRIPTION
## 概要

診療報酬加算・院内掲示事項の表示を整理しました。

- /description の診療報酬上の加算セクションを開閉カード形式に変更
- 生活習慣病管理料を /consultation の内科セクションへ移動
- 地域包括診療加算・地域包括診療料を機能強化型加算のお知らせへ移動
- 在宅医療関連の掲示を /home-medical-care へ移動
- 情報通信機器を用いた診療の掲示を /online へ移動
- ベースアップ評価料を診療報酬上の加算セクションへ配置

## 確認

- http://localhost:3000/description 200 OK
- http://localhost:3000/consultation 200 OK
- http://localhost:3000/home-medical-care 200 OK
- http://localhost:3000/online 200 OK
- npm run lint 成功

既存の別ファイル由来の lint warning は残っています。