### PR TITLE
[codex] 開発Dockerとデプロイ設定を整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Docker Compose環境変数
+# docker-compose.yml の変数展開用設定
+# ※ Nextアプリの環境変数は next/.env に設定してください
+
+# サーバー名（本番ではドメイン名を設定）
+SERVER_NAME=localhost
+
+# MySQL設定（本番では必ず変更）
+MYSQL_ROOT_PASSWORD=your_strong_root_password_here
+MYSQL_DATABASE=app_db
+MYSQL_USER=app_user
+MYSQL_PASSWORD=your_strong_app_password_here
+
+# NextAuth URL（docker-compose.yml で参照）
+NEXTAUTH_URL=https://your-domain.com
+
+# SSL証明書設定（Let's Encrypt）
+CERTBOT_EMAIL=admin@your-domain.com
+CERTBOT_DOMAINS=your-domain.com,www.your-domain.com
+CERT_NAME=your-domain.com

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -89,6 +89,13 @@ jobs:
 
             cd ~/mizuki-hp
 
+            # Load environment variables from .env
+            if [ -f .env ]; then
+              set -a
+              . ./.env
+              set +a
+            fi
+
             echo "Pulling latest code..."
             git fetch origin main
             git checkout main
@@ -138,7 +145,9 @@ jobs:
             docker compose -f docker-compose.yml up -d next nginx
 
             echo "Checking SSL certificate..."
-            CERT_PATH="./certbot/conf/live/mizuki-clinic.jp/fullchain.pem"
+            # CERT_NAME is derived from SERVER_NAME in .env
+            CERT_NAME="${CERT_NAME:-${SERVER_NAME:-localhost}}"
+            CERT_PATH="./certbot/conf/live/${CERT_NAME}/fullchain.pem"
             if [ ! -f "$CERT_PATH" ]; then
               echo "SSL certificate not found. Obtaining certificate..."
               if docker compose --profile ssl -f docker-compose.yml run --rm certbot; then
@@ -156,5 +165,24 @@ jobs:
 
             echo "Cleaning up old images..."
             docker image prune -f
+
+            echo "Running health check..."
+            HEALTH_URL="http://localhost:2999/api/health"
+            HEALTH_OK=false
+            for i in $(seq 1 10); do
+              if curl -sf "$HEALTH_URL" > /dev/null 2>&1; then
+                echo "Health check passed!"
+                HEALTH_OK=true
+                break
+              fi
+              echo "Waiting for application to be ready... ($i/10)"
+              sleep 3
+            done
+
+            if [ "$HEALTH_OK" = "false" ]; then
+              echo "ERROR: Health check failed after 30 seconds"
+              echo "Application is not responding correctly"
+              exit 1
+            fi
 
             echo "Deployment completed successfully!"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!next/.env.example
 
 # vercel
 .vercel
@@ -61,7 +63,7 @@ mysql/data/
 # certbot
 certbot/
 
-docker-compose.override.yml
+docker-compose.local.yml
 
 # backup
 *.sql

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "files.watcherExclude": {
+    "**/.git/**": true,
+    "**/node_modules/**": true,
+    "**/.next/**": true,
+    "**/mysql/data/**": true,
+    "**/certbot/conf/**": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/.next": true,
+    "**/mysql/data": true,
+    "**/certbot/conf": true
+  },
+  "files.exclude": {
+    "**/.next/cache": true
+  }
+}

--- a/README.dev.md
+++ b/README.dev.md
@@ -99,3 +99,35 @@ docker compose -f docker-compose.dev.yml restart next
 
 開発環境は `mysql_dev_data` ボリューム、本番環境は `./mysql/data` を使用しています。
 混在しないように注意してください。
+
+### 開発環境が重い
+
+まずCPUとメモリ、キャッシュ容量を確認:
+
+```bash
+ps -eo pid,ppid,pcpu,pmem,rss,etime,comm,args --sort=-pcpu | head -20
+free -h
+du -sh next/.next /home/seta/.npm
+```
+
+効果があった対処:
+
+- VS Codeの監視対象から `node_modules`、`.next`、`mysql/data`、`certbot/conf` を除外する
+- `next/.next/cache` を削除する
+- npm/npxキャッシュを掃除する
+- 使っていないVS Code拡張を無効化またはアンインストールする
+- VS Codeで `Developer: Reload Window` を実行する
+
+キャッシュ削除例:
+
+```bash
+# Next.jsキャッシュが通常ユーザーで消せない場合はDocker経由で削除
+docker run --rm -v /home/seta/mizuki-hp/next/.next:/target nginx:1.27-alpine sh -c 'rm -rf /target/cache'
+
+npm cache verify
+npm cache clean --force
+rm -rf /home/seta/.npm/_npx
+```
+
+このリポジトリでは `.vscode/settings.json` にVS Codeの監視除外設定を置いています。
+Codexを使う場合、`openai.chatgpt` 拡張は残し、不要なAI拡張を同時に動かさないようにしてください。

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,9 +2,10 @@ services:
   next:
     build:
       context: ./next
-      dockerfile: Dockerfile
-    image: mizuki-hp-local:latest
+      dockerfile: Dockerfile.dev
+    image: mizuki-hp-dev:latest
     container_name: next_app_dev
+    working_dir: /app
     ports:
       - "3000:3000"
     env_file:
@@ -16,10 +17,8 @@ services:
       - NODE_ENV=development
     volumes:
       - ./next:/app
-      - /app/node_modules
-      - /app/.next
       - ./uploads:/app/public/uploads
-    command: sh -c "npx prisma generate && npx prisma db push && npm run dev"
+    command: sh -c "npx prisma generate && npx prisma db push && npm run dev -- -H 0.0.0.0"
     depends_on:
       mysql:
         condition: service_healthy
@@ -46,7 +45,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 180s
 
   nginx:
     image: nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - ./next/.env
     environment:
-      - DATABASE_URL=mysql://app_user:${MYSQL_PASSWORD:-app_pass}@mysql:3306/app_db
+      - DATABASE_URL=mysql://${MYSQL_USER:-app_user}:${MYSQL_PASSWORD:-app_pass}@mysql:3306/${MYSQL_DATABASE:-app_db}
       - NEXTAUTH_URL=${NEXTAUTH_URL:-https://mizuki-clinic.jp}
       - NEXTAUTH_TRUST_HOST=true
       - NODE_ENV=production
@@ -51,6 +51,7 @@ services:
       - "443:443"
     environment:
       - SERVER_NAME=${SERVER_NAME:-localhost}
+      - CERT_NAME=${CERT_NAME:-${SERVER_NAME:-localhost}}
     volumes:
       - ./nginx/default.conf.template:/etc/nginx/conf.d/default.conf.template:ro
       - ./nginx/docker-entrypoint.sh:/docker-entrypoint.sh:ro
@@ -71,4 +72,4 @@ services:
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
-    command: certonly --webroot --webroot-path=/var/www/certbot --email k_ryuji@setaseisakusyo.com --agree-tos --no-eff-email -d mizuki-clinic.jp -d www.mizuki-clinic.jp --keep-until-expiring
+    command: certonly --webroot --webroot-path=/var/www/certbot --email ${CERTBOT_EMAIL:-admin@example.com} --agree-tos --no-eff-email -d ${CERTBOT_DOMAINS:-localhost} --keep-until-expiring

--- a/next/Dockerfile.dev
+++ b/next/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+USER node

--- a/next/src/app/api/health/route.ts
+++ b/next/src/app/api/health/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return NextResponse.json({ status: "ok" }, { status: 200 });
+  } catch {
+    return NextResponse.json({ status: "error" }, { status: 503 });
+  }
+}

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 
-CERT_PATH="/etc/letsencrypt/live/mizuki-clinic.jp/fullchain.pem"
+# CERT_NAME: 証明書ディレクトリ名（デフォルトはSERVER_NAME）
+CERT_NAME="${CERT_NAME:-${SERVER_NAME}}"
+CERT_PATH="/etc/letsencrypt/live/${CERT_NAME}/fullchain.pem"
 
 # 環境変数を展開
 envsubst '${SERVER_NAME}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
@@ -16,8 +18,8 @@ server {
     listen 443 ssl;
     server_name ${SERVER_NAME};
 
-    ssl_certificate /etc/letsencrypt/live/mizuki-clinic.jp/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/mizuki-clinic.jp/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${CERT_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${CERT_NAME}/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
@@ -41,7 +43,7 @@ server {
     }
 
     location / {
-        proxy_pass http://next_app:3000;
+        proxy_pass http://next:3000;
         proxy_http_version 1.1;
 
         proxy_set_header Host $host;
@@ -58,13 +60,13 @@ server {
     }
 
     location /_next/static/ {
-        proxy_pass http://next_app:3000;
+        proxy_pass http://next:3000;
         proxy_cache_valid 200 60m;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
     location /static/ {
-        proxy_pass http://next_app:3000;
+        proxy_pass http://next:3000;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 }
@@ -74,16 +76,17 @@ server {
     listen 443 ssl;
     server_name www.${SERVER_NAME};
 
-    ssl_certificate /etc/letsencrypt/live/mizuki-clinic.jp/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/mizuki-clinic.jp/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${CERT_NAME}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${CERT_NAME}/privkey.pem;
 
     ssl_protocols TLSv1.2 TLSv1.3;
 
     return 301 https://${SERVER_NAME}$request_uri;
 }
 EOF
-    # SERVER_NAME を再度展開
+    # SERVER_NAME と CERT_NAME を再度展開
     sed -i "s/\${SERVER_NAME}/${SERVER_NAME}/g" /etc/nginx/conf.d/default.conf
+    sed -i "s/\${CERT_NAME}/${CERT_NAME}/g" /etc/nginx/conf.d/default.conf
 else
     echo "SSL certificate not found. Running HTTP only..."
     # HTTPSリダイレクトを無効化し、HTTPで直接サービス
@@ -114,7 +117,7 @@ server {
     }
 
     location / {
-        proxy_pass http://next_app:3000;
+        proxy_pass http://next:3000;
         proxy_http_version 1.1;
 
         proxy_set_header Host \$host;
@@ -131,13 +134,13 @@ server {
     }
 
     location /_next/static/ {
-        proxy_pass http://next_app:3000;
+        proxy_pass http://next:3000;
         proxy_cache_valid 200 60m;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
     location /static/ {
-        proxy_pass http://next_app:3000;
+        proxy_pass http://next:3000;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 }


### PR DESCRIPTION
## 概要

stash に残っていたインフラ・開発環境まわりの変更を整理しました。

- 開発用 `Dockerfile.dev` と `docker-compose.dev.yml` を追加・調整
- 本番 compose の環境変数化と証明書名 `CERT_NAME` 対応を追加
- nginx entrypoint の証明書パスと compose service 名参照を調整
- deploy workflow に `.env` 読み込み、証明書名の環境変数化、health check を追加
- `/api/health` を追加して DB 接続込みのヘルスチェックに対応
- `.env.example` と VS Code watcher 除外設定を追加
- 開発環境が重い場合の対処を README に追記

## 確認

- `docker compose -f docker-compose.dev.yml config`
- `docker compose -f docker-compose.yml config`
- `sh -n nginx/docker-entrypoint.sh`
- `http://localhost:3000/api/health` 200 OK
- `npm run lint` 成功

既存の別ファイル由来の lint warning は残っています。
