### PR TITLE
[codex] Add haiku backup export

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -9,7 +9,7 @@
 - MySQLデータは `mysql_dev_data` ボリュームに保存
 
 ### 本番環境（docker-compose.yml）
-- 固定イメージ `ghcr.io/ryuji0128/mizuki-hp:latest` を使用
+- 固定イメージ `ghcr.io/seta-seisakusyo/mizuki-hp:latest` を使用
 - コード変更は反映されない（再ビルドが必要）
 - `node server.js` で起動
 - MySQLデータは `./mysql/data` に保存
@@ -66,6 +66,43 @@ NEXTAUTH_URL=https://mizuki-clinic.jp
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY=your-site-key
 RECAPTCHA_SECRET_KEY=your-secret-key
 ```
+
+
+## 院長俳句バックアップ
+
+管理画面の `バックアップDL` ボタンに加えて、cron から同じJSONバックアップを作成できます。
+
+1. cron 用トークンを生成し、`next/.env` に設定します。
+
+```bash
+openssl rand -hex 32
+```
+
+`next/.env`:
+
+```bash
+HAIKU_BACKUP_TOKEN=generated-token-value
+```
+
+2. 本番コンテナを再起動して環境変数を反映します。
+
+```bash
+docker compose up -d next
+```
+
+3. 手動でバックアップできることを確認します。
+
+```bash
+./scripts/backup-haiku.sh
+```
+
+4. cron に登録します。例: 毎日 3:30 に実行。
+
+```cron
+30 3 * * * cd /home/seta/mizuki-hp && ./scripts/backup-haiku.sh >> /tmp/mizuki-haiku-backup.log 2>&1
+```
+
+バックアップは既定で `./backups/haiku/` に保存され、30日より古い `mizuki-haiku-backup-*.json` は削除されます。保存先や保持日数を変える場合は `HAIKU_BACKUP_DIR`、`HAIKU_BACKUP_KEEP_DAYS`、`HAIKU_BACKUP_URL` を cron 側で指定してください。
 
 ## セキュリティチェックリスト
 

--- a/next/.env.example
+++ b/next/.env.example
@@ -26,3 +26,6 @@ SITE_URL=https://your-domain.com
 # Google OAuth（管理画面認証用、オプション）
 # AUTH_GOOGLE_ID=your-google-client-id
 # AUTH_GOOGLE_SECRET=your-google-client-secret
+# 院長俳句バックアップ（cron用、任意）
+# openssl rand -hex 32 などで長いランダム値を設定してください
+HAIKU_BACKUP_TOKEN=your-haiku-backup-token

--- a/next/src/app/api/blog/backup/route.ts
+++ b/next/src/app/api/blog/backup/route.ts
@@ -1,0 +1,164 @@
+import { timingSafeEqual } from "crypto";
+import { readFile } from "fs/promises";
+import path from "path";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { apiError, checkAdminAuth } from "@/lib/apiUtils";
+import logger from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UPLOAD_URL_PREFIX = "/uploads/";
+const MIME_BY_EXT: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+type BlogBackupImage =
+  | {
+      path: string;
+      mimeType: string;
+      encoding: "base64";
+      data: string;
+    }
+  | {
+      path: string;
+      missing: true;
+    }
+  | null;
+
+function getSafeUploadPath(imageUrl: string | null): string | null {
+  if (!imageUrl?.startsWith(UPLOAD_URL_PREFIX)) {
+    return null;
+  }
+
+  let relativePath: string;
+  try {
+    relativePath = decodeURIComponent(imageUrl.slice(UPLOAD_URL_PREFIX.length));
+  } catch {
+    return null;
+  }
+
+  if (!relativePath || relativePath.includes("\0")) {
+    return null;
+  }
+
+  const uploadRoot = path.resolve(process.cwd(), "public", "uploads");
+  const filePath = path.resolve(uploadRoot, relativePath);
+
+  if (!filePath.startsWith(`${uploadRoot}${path.sep}`)) {
+    return null;
+  }
+
+  return filePath;
+}
+
+async function readBackupImage(imageUrl: string | null): Promise<BlogBackupImage> {
+  const filePath = getSafeUploadPath(imageUrl);
+  if (!imageUrl || !filePath) {
+    return null;
+  }
+
+  try {
+    const buffer = await readFile(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    return {
+      path: imageUrl,
+      mimeType: MIME_BY_EXT[ext] ?? "application/octet-stream",
+      encoding: "base64",
+      data: buffer.toString("base64"),
+    };
+  } catch (error) {
+    logger.warn("俳句バックアップ画像の読み込みに失敗しました", { imageUrl, error });
+    return {
+      path: imageUrl,
+      missing: true,
+    };
+  }
+}
+
+function backupFileName(exportedAt: Date) {
+  const timestamp = exportedAt
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+  return `mizuki-haiku-backup-${timestamp}.json`;
+}
+
+function isBackupTokenAuthorized(request: NextRequest) {
+  const expectedToken = process.env.HAIKU_BACKUP_TOKEN;
+  if (!expectedToken) {
+    return false;
+  }
+
+  const authorization = request.headers.get("authorization") ?? "";
+  const providedToken = authorization.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length).trim()
+    : "";
+
+  if (!providedToken) {
+    return false;
+  }
+
+  const expected = Buffer.from(expectedToken);
+  const provided = Buffer.from(providedToken);
+  if (expected.length !== provided.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expected, provided);
+}
+
+export async function GET(request: NextRequest) {
+  if (!isBackupTokenAuthorized(request)) {
+    const authResult = await checkAdminAuth();
+    if (!authResult.isAdmin) {
+      return authResult.response;
+    }
+  }
+
+  try {
+    const exportedAt = new Date();
+    const blogs = await prisma.blog.findMany({
+      orderBy: { createdAt: "asc" },
+    });
+
+    const backupBlogs = await Promise.all(
+      blogs.map(async (blog) => ({
+        id: blog.id,
+        title: blog.title,
+        content: blog.content,
+        imageUrl: blog.imageUrl,
+        imagePosition: blog.imagePosition,
+        createdAt: blog.createdAt.toISOString(),
+        updatedAt: blog.updatedAt.toISOString(),
+        image: await readBackupImage(blog.imageUrl),
+      }))
+    );
+
+    const backup = {
+      schemaVersion: 1,
+      source: "mizuki-hp-blog",
+      exportedAt: exportedAt.toISOString(),
+      blogCount: backupBlogs.length,
+      imageCount: backupBlogs.filter((blog) => blog.image && "data" in blog.image).length,
+      missingImageCount: backupBlogs.filter((blog) => blog.image && "missing" in blog.image).length,
+      blogs: backupBlogs,
+    };
+
+    return new NextResponse(JSON.stringify(backup, null, 2), {
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${backupFileName(exportedAt)}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    logger.error("俳句バックアップ作成エラー:", error);
+    return apiError("バックアップの作成に失敗しました", 500);
+  }
+}

--- a/next/src/app/home-medical-care/Message01.tsx
+++ b/next/src/app/home-medical-care/Message01.tsx
@@ -35,15 +35,6 @@ export default function Message02() {
         </ListItem>
       </List>
 
-      <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a", mb: 1.5 }}>
-        在宅医療DX情報活用加算について
-      </Typography>
-      <Typography variant="body1" sx={{ mb: 1, ml: 2, lineHeight: 1.8 }}>
-        当院では居宅同意取得型のオンライン資格確認システムを活用し、取得した診療情報を計画的な医学管理のもと訪問診療に活用しています。
-      </Typography>
-      <Typography variant="body1" sx={{ mb: 4, ml: 2, lineHeight: 1.8 }}>
-        また、マイナ保険証利用促進等、医療DXを通じて質の高い医療の提供に努めています。
-      </Typography>
 
       <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a", mb: 1.5 }}>
         訪問診療と往診の違いは？
@@ -65,11 +56,21 @@ export default function Message02() {
       <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a", mb: 1.5 }}>
         高額療養費制度とは？
       </Typography>
-      <Typography variant="body1" sx={{ ml: 2, lineHeight: 1.8 }}>
+      <Typography variant="body1" sx={{ mb: 4, ml: 2, lineHeight: 1.8 }}>
         健康保険の毎月の自己負担金が一定以上になった場合、払い戻しが受けられます。
         上限額は、年齢や所得、利用している健康保険の種類によっても異なりますので、
         詳しくは、健康保険証に記載された問い合わせ先（保険者）に確認してください。
         この払い戻しについては、自主的に申請することが必要です。
+      </Typography>
+
+      <Typography variant="h6" sx={{ fontWeight: 600, color: "#1a1a1a", mb: 1.5 }}>
+        在宅医療DX情報活用加算について
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 1, ml: 2, lineHeight: 1.8 }}>
+        当院では居宅同意取得型のオンライン資格確認システムを活用し、取得した診療情報を計画的な医学管理のもと訪問診療に活用しています。
+      </Typography>
+      <Typography variant="body1" sx={{ ml: 2, lineHeight: 1.8 }}>
+        また、マイナ保険証利用促進等、医療DXを通じて質の高い医療の提供に努めています。
       </Typography>
     </Box>
   );

--- a/next/src/app/portal-admin/blog/page.tsx
+++ b/next/src/app/portal-admin/blog/page.tsx
@@ -9,6 +9,7 @@ import type { BlogItem } from "@/types/models";
 export default function AdminBlogPage() {
   const [blogs, setBlogs] = useState<BlogItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [backupLoading, setBackupLoading] = useState(false);
 
   // 投稿一覧を取得
   const fetchBlogs = async () => {
@@ -47,19 +48,60 @@ export default function AdminBlogPage() {
     }
   };
 
+  const handleBackupDownload = async () => {
+    setBackupLoading(true);
+
+    try {
+      const res = await fetch("/api/blog/backup");
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || "バックアップの作成に失敗しました");
+      }
+
+      const blob = await res.blob();
+      const disposition = res.headers.get("Content-Disposition") || "";
+      const fileName =
+        disposition.match(/filename="([^"]+)"/)?.[1] ||
+        `mizuki-haiku-backup-${new Date().toISOString().slice(0, 10)}.json`;
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("バックアップエラー:", err);
+      alert(err instanceof Error ? err.message : "バックアップ中にエラーが発生しました");
+    } finally {
+      setBackupLoading(false);
+    }
+  };
+
   if (loading) return <p className="text-center mt-10">読み込み中...</p>;
 
   return (
     <main className="max-w-3xl mx-auto p-6 space-y-6">
       {/* ✅ 新規作成ボタン */}
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center">
         <h1 className="text-2xl font-bold flex items-center gap-2">🖊️ 俳句一覧</h1>
-        <Link
-          href="/portal-admin/blog/new"
-          className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition"
-        >
-          ＋ 新規俳句
-        </Link>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleBackupDownload}
+            disabled={backupLoading}
+            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 disabled:bg-gray-400 transition"
+          >
+            {backupLoading ? "作成中..." : "バックアップDL"}
+          </button>
+          <Link
+            href="/portal-admin/blog/new"
+            className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition"
+          >
+            ＋ 新規俳句
+          </Link>
+        </div>
       </div>
 
       {/* 投稿リスト */}

--- a/scripts/backup-haiku.sh
+++ b/scripts/backup-haiku.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Haiku backup script for host cron.
+# Example cron: 30 3 * * * cd /home/seta/mizuki-hp && ./scripts/backup-haiku.sh >> /tmp/mizuki-haiku-backup.log 2>&1
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+APP_URL="${HAIKU_BACKUP_URL:-http://127.0.0.1:2999}"
+BACKUP_DIR="${HAIKU_BACKUP_DIR:-./backups/haiku}"
+ENV_FILE="${HAIKU_BACKUP_ENV_FILE:-./next/.env}"
+KEEP_DAYS="${HAIKU_BACKUP_KEEP_DAYS:-30}"
+
+read_env_value() {
+  local file="$1"
+  local key="$2"
+  grep -E "^${key}=" "$file" | tail -n 1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
+}
+
+if [ -z "${HAIKU_BACKUP_TOKEN:-}" ] && [ -f "$ENV_FILE" ]; then
+  HAIKU_BACKUP_TOKEN="$(read_env_value "$ENV_FILE" "HAIKU_BACKUP_TOKEN" || true)"
+fi
+
+if [ -z "${HAIKU_BACKUP_TOKEN:-}" ]; then
+  echo "[$(date)] ERROR: HAIKU_BACKUP_TOKEN is not set."
+  exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+DATE=$(date -u +%Y%m%dT%H%M%SZ)
+BACKUP_FILE="${BACKUP_DIR}/mizuki-haiku-backup-${DATE}.json"
+TMP_FILE="${BACKUP_FILE}.tmp"
+
+cleanup() {
+  rm -f "$TMP_FILE"
+}
+trap cleanup EXIT
+
+curl -fsS   -H "Authorization: Bearer ${HAIKU_BACKUP_TOKEN}"   "${APP_URL%/}/api/blog/backup"   -o "$TMP_FILE"
+
+mv "$TMP_FILE" "$BACKUP_FILE"
+trap - EXIT
+
+find "$BACKUP_DIR" -type f -name 'mizuki-haiku-backup-*.json' -mtime +"$KEEP_DAYS" -delete
+
+echo "[$(date)] Haiku backup created: $BACKUP_FILE"


### PR DESCRIPTION
## Summary
- Add an admin-protected haiku backup export API that can include uploaded images as base64 JSON data
- Add a backup download button to the haiku admin list and a host cron script for scheduled backups
- Move the home medical care DX notice below the high-cost medical expense section
- Document HAIKU_BACKUP_TOKEN and cron setup

## Validation
- npm run lint succeeded with existing warnings only
- npx tsc --noEmit succeeded
- bash -n scripts/backup-haiku.sh succeeded
- git diff --check succeeded

## Notes
- Production cron still needs HAIKU_BACKUP_TOKEN added to next/.env, docker compose up -d next, and crontab registration.