### PR TITLE
[codex] Fix haiku backup memory usage

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -70,39 +70,25 @@ RECAPTCHA_SECRET_KEY=your-secret-key
 
 ## 院長俳句バックアップ
 
-管理画面の `バックアップDL` ボタンに加えて、cron から同じJSONバックアップを作成できます。
+管理画面の `バックアップDL` ボタンでは、俳句投稿データの軽量JSONをダウンロードできます。画像ファイルを含めた定期バックアップは、cron から `scripts/backup-haiku.sh` を実行します。
 
-1. cron 用トークンを生成し、`next/.env` に設定します。
+`backup-haiku.sh` は Next.js API を経由せず、MySQL の `Blog` テーブル dump と `uploads` ディレクトリをまとめた tar.gz を作成します。
 
-```bash
-openssl rand -hex 32
-```
-
-`next/.env`:
-
-```bash
-HAIKU_BACKUP_TOKEN=generated-token-value
-```
-
-2. 本番コンテナを再起動して環境変数を反映します。
-
-```bash
-docker compose up -d next
-```
-
-3. 手動でバックアップできることを確認します。
+1. 手動でバックアップできることを確認します。
 
 ```bash
 ./scripts/backup-haiku.sh
 ```
 
-4. cron に登録します。例: 毎日 3:30 に実行。
+2. cron に登録します。例: 毎日 3:30 に実行。
 
 ```cron
-30 3 * * * cd /home/seta/mizuki-hp && ./scripts/backup-haiku.sh >> /tmp/mizuki-haiku-backup.log 2>&1
+30 3 * * * cd /home/ubuntu/mizuki-hp && ./scripts/backup-haiku.sh >> /tmp/mizuki-haiku-backup.log 2>&1
 ```
 
-バックアップは既定で `./backups/haiku/` に保存され、30日より古い `mizuki-haiku-backup-*.json` は削除されます。保存先や保持日数を変える場合は `HAIKU_BACKUP_DIR`、`HAIKU_BACKUP_KEEP_DAYS`、`HAIKU_BACKUP_URL` を cron 側で指定してください。
+バックアップは既定で `./backups/haiku/` に保存され、30日より古い `mizuki-haiku-backup-*.tar.gz` は削除されます。保存先や保持日数を変える場合は `HAIKU_BACKUP_DIR`、`HAIKU_BACKUP_KEEP_DAYS` を cron 側で指定してください。
+
+バックアップAPIを cron 以外から直接呼び出したい場合のみ、`next/.env` に `HAIKU_BACKUP_TOKEN` を設定してください。
 
 ## セキュリティチェックリスト
 

--- a/next/src/app/api/blog/backup/route.ts
+++ b/next/src/app/api/blog/backup/route.ts
@@ -1,6 +1,4 @@
 import { timingSafeEqual } from "crypto";
-import { readFile } from "fs/promises";
-import path from "path";
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { apiError, checkAdminAuth } from "@/lib/apiUtils";
@@ -8,78 +6,6 @@ import logger from "@/lib/logger";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-const UPLOAD_URL_PREFIX = "/uploads/";
-const MIME_BY_EXT: Record<string, string> = {
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".png": "image/png",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-};
-
-type BlogBackupImage =
-  | {
-      path: string;
-      mimeType: string;
-      encoding: "base64";
-      data: string;
-    }
-  | {
-      path: string;
-      missing: true;
-    }
-  | null;
-
-function getSafeUploadPath(imageUrl: string | null): string | null {
-  if (!imageUrl?.startsWith(UPLOAD_URL_PREFIX)) {
-    return null;
-  }
-
-  let relativePath: string;
-  try {
-    relativePath = decodeURIComponent(imageUrl.slice(UPLOAD_URL_PREFIX.length));
-  } catch {
-    return null;
-  }
-
-  if (!relativePath || relativePath.includes("\0")) {
-    return null;
-  }
-
-  const uploadRoot = path.resolve(process.cwd(), "public", "uploads");
-  const filePath = path.resolve(uploadRoot, relativePath);
-
-  if (!filePath.startsWith(`${uploadRoot}${path.sep}`)) {
-    return null;
-  }
-
-  return filePath;
-}
-
-async function readBackupImage(imageUrl: string | null): Promise<BlogBackupImage> {
-  const filePath = getSafeUploadPath(imageUrl);
-  if (!imageUrl || !filePath) {
-    return null;
-  }
-
-  try {
-    const buffer = await readFile(filePath);
-    const ext = path.extname(filePath).toLowerCase();
-    return {
-      path: imageUrl,
-      mimeType: MIME_BY_EXT[ext] ?? "application/octet-stream",
-      encoding: "base64",
-      data: buffer.toString("base64"),
-    };
-  } catch (error) {
-    logger.warn("俳句バックアップ画像の読み込みに失敗しました", { imageUrl, error });
-    return {
-      path: imageUrl,
-      missing: true,
-    };
-  }
-}
 
 function backupFileName(exportedAt: Date) {
   const timestamp = exportedAt
@@ -127,8 +53,14 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: "asc" },
     });
 
-    const backupBlogs = await Promise.all(
-      blogs.map(async (blog) => ({
+    const backup = {
+      schemaVersion: 2,
+      source: "mizuki-hp-blog",
+      exportedAt: exportedAt.toISOString(),
+      blogCount: blogs.length,
+      imageMode: "metadata-only",
+      note: "Uploaded image files are backed up by scripts/backup-haiku.sh as uploads.tar.gz.",
+      blogs: blogs.map((blog) => ({
         id: blog.id,
         title: blog.title,
         content: blog.content,
@@ -136,18 +68,7 @@ export async function GET(request: NextRequest) {
         imagePosition: blog.imagePosition,
         createdAt: blog.createdAt.toISOString(),
         updatedAt: blog.updatedAt.toISOString(),
-        image: await readBackupImage(blog.imageUrl),
-      }))
-    );
-
-    const backup = {
-      schemaVersion: 1,
-      source: "mizuki-hp-blog",
-      exportedAt: exportedAt.toISOString(),
-      blogCount: backupBlogs.length,
-      imageCount: backupBlogs.filter((blog) => blog.image && "data" in blog.image).length,
-      missingImageCount: backupBlogs.filter((blog) => blog.image && "missing" in blog.image).length,
-      blogs: backupBlogs,
+      })),
     };
 
     return new NextResponse(JSON.stringify(backup, null, 2), {

--- a/scripts/backup-haiku.sh
+++ b/scripts/backup-haiku.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 # Haiku backup script for host cron.
-# Example cron: 30 3 * * * cd /home/seta/mizuki-hp && ./scripts/backup-haiku.sh >> /tmp/mizuki-haiku-backup.log 2>&1
+# Example cron: 30 3 * * * cd /home/ubuntu/mizuki-hp && ./scripts/backup-haiku.sh >> /tmp/mizuki-haiku-backup.log 2>&1
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-APP_URL="${HAIKU_BACKUP_URL:-http://127.0.0.1:2999}"
 BACKUP_DIR="${HAIKU_BACKUP_DIR:-./backups/haiku}"
-ENV_FILE="${HAIKU_BACKUP_ENV_FILE:-./next/.env}"
+ENV_FILE="${HAIKU_BACKUP_COMPOSE_ENV_FILE:-./.env}"
 KEEP_DAYS="${HAIKU_BACKUP_KEEP_DAYS:-30}"
 
 read_env_value() {
@@ -17,31 +16,58 @@ read_env_value() {
   grep -E "^${key}=" "$file" | tail -n 1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
 }
 
-if [ -z "${HAIKU_BACKUP_TOKEN:-}" ] && [ -f "$ENV_FILE" ]; then
-  HAIKU_BACKUP_TOKEN="$(read_env_value "$ENV_FILE" "HAIKU_BACKUP_TOKEN" || true)"
+if [ -f "$ENV_FILE" ]; then
+  MYSQL_DATABASE="${MYSQL_DATABASE:-$(read_env_value "$ENV_FILE" "MYSQL_DATABASE" || true)}"
+  MYSQL_USER="${MYSQL_USER:-$(read_env_value "$ENV_FILE" "MYSQL_USER" || true)}"
+  MYSQL_PASSWORD="${MYSQL_PASSWORD:-$(read_env_value "$ENV_FILE" "MYSQL_PASSWORD" || true)}"
 fi
 
-if [ -z "${HAIKU_BACKUP_TOKEN:-}" ]; then
-  echo "[$(date)] ERROR: HAIKU_BACKUP_TOKEN is not set."
-  exit 1
-fi
+MYSQL_DATABASE="${MYSQL_DATABASE:-app_db}"
+MYSQL_USER="${MYSQL_USER:-app_user}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-app_pass}"
 
 mkdir -p "$BACKUP_DIR"
 
 DATE=$(date -u +%Y%m%dT%H%M%SZ)
-BACKUP_FILE="${BACKUP_DIR}/mizuki-haiku-backup-${DATE}.json"
-TMP_FILE="${BACKUP_FILE}.tmp"
+BACKUP_FILE="${BACKUP_DIR}/mizuki-haiku-backup-${DATE}.tar.gz"
+TMP_DIR="${BACKUP_DIR}/.mizuki-haiku-backup-${DATE}"
 
 cleanup() {
-  rm -f "$TMP_FILE"
+  rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
 
-curl -fsS   -H "Authorization: Bearer ${HAIKU_BACKUP_TOKEN}"   "${APP_URL%/}/api/blog/backup"   -o "$TMP_FILE"
+mkdir -p "$TMP_DIR"
 
-mv "$TMP_FILE" "$BACKUP_FILE"
+docker compose exec -T \
+  -e MYSQL_PWD="$MYSQL_PASSWORD" \
+  mysql mysqldump \
+  --no-tablespaces \
+  -u "$MYSQL_USER" \
+  "$MYSQL_DATABASE" \
+  Blog | gzip > "${TMP_DIR}/blog.sql.gz"
+
+if [ -d ./uploads ]; then
+  tar -czf "${TMP_DIR}/uploads.tar.gz" -C ./uploads .
+else
+  tar -czf "${TMP_DIR}/uploads.tar.gz" --files-from /dev/null
+fi
+
+cat > "${TMP_DIR}/manifest.json" <<EOF
+{
+  "schemaVersion": 1,
+  "source": "mizuki-hp-haiku-cron",
+  "createdAt": "${DATE}",
+  "database": "${MYSQL_DATABASE}",
+  "files": ["blog.sql.gz", "uploads.tar.gz"]
+}
+EOF
+
+tar -czf "$BACKUP_FILE" -C "$TMP_DIR" .
+
+find "$BACKUP_DIR" -type f -name 'mizuki-haiku-backup-*.tar.gz' -mtime +"$KEEP_DAYS" -delete
+
 trap - EXIT
-
-find "$BACKUP_DIR" -type f -name 'mizuki-haiku-backup-*.json' -mtime +"$KEEP_DAYS" -delete
+cleanup
 
 echo "[$(date)] Haiku backup created: $BACKUP_FILE"


### PR DESCRIPTION
## Summary
- Stop embedding uploaded images as base64 in the haiku backup API response
- Keep the admin/API JSON export lightweight with image metadata only
- Change the cron backup script to create a tar.gz containing Blog table SQL dump, uploads tarball, and manifest
- Update docs for the new cron backup behavior

## Root Cause
The production backup endpoint loaded uploaded image files into memory and serialized them into one JSON response. On production data this exceeded the Next.js heap limit and restarted next_app.

## Validation
- npm run lint succeeded with existing warnings only
- npx tsc --noEmit succeeded
- bash -n scripts/backup-haiku.sh succeeded
- HAIKU_BACKUP_DIR=/tmp/mizuki-haiku-backup-test ./scripts/backup-haiku.sh created a tar.gz containing blog.sql.gz, uploads.tar.gz, and manifest.json
- git diff --check succeeded

## Production Notes
After this is merged and deployed, rerun ./scripts/backup-haiku.sh on the server. The output will be backups/haiku/mizuki-haiku-backup-*.tar.gz, not JSON.