### PR TITLE
[codex] Fix haiku image upload preview

### DIFF
--- a/next/src/app/api/admin/upload/route.ts
+++ b/next/src/app/api/admin/upload/route.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "fs/promises";
 import crypto from "crypto";
 import { NextResponse } from "next/server";
 import path from "path";
+import logger from "@/lib/logger";
 
 // 許可されたMIMEタイプと対応する拡張子
 const ALLOWED_TYPES: Record<string, string> = {
@@ -20,8 +21,24 @@ const MAGIC_BYTES: Record<string, number[]> = {
   "image/webp": [0x52, 0x49, 0x46, 0x46], // RIFF
 };
 
-// 最大ファイルサイズ (5MB)
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
+// 最大ファイルサイズ (nginx の client_max_body_size と合わせる)
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+function normalizeMimeType(mimeType: string): string {
+  if (mimeType === "image/jpg" || mimeType === "image/pjpeg") {
+    return "image/jpeg";
+  }
+  return mimeType;
+}
+
+function inferMimeTypeFromFileName(fileName: string): string | null {
+  const ext = path.extname(fileName).toLowerCase();
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".png") return "image/png";
+  if (ext === ".gif") return "image/gif";
+  if (ext === ".webp") return "image/webp";
+  return null;
+}
 
 /**
  * ファイルのマジックバイトを検証
@@ -29,6 +46,7 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024;
 function validateMagicBytes(buffer: Buffer, mimeType: string): boolean {
   const expectedBytes = MAGIC_BYTES[mimeType];
   if (!expectedBytes) return false;
+  if (buffer.length < expectedBytes.length) return false;
 
   for (let i = 0; i < expectedBytes.length; i++) {
     if (buffer[i] !== expectedBytes[i]) {
@@ -38,6 +56,7 @@ function validateMagicBytes(buffer: Buffer, mimeType: string): boolean {
 
   // WebPの場合、追加でWEBPシグネチャをチェック
   if (mimeType === "image/webp") {
+    if (buffer.length < 12) return false;
     const webpSignature = [0x57, 0x45, 0x42, 0x50]; // WEBP
     for (let i = 0; i < webpSignature.length; i++) {
       if (buffer[8 + i] !== webpSignature[i]) {
@@ -72,13 +91,17 @@ export async function POST(req: Request) {
     // ファイルサイズチェック
     if (file.size > MAX_FILE_SIZE) {
       return NextResponse.json(
-        { error: "ファイルサイズは5MB以下にしてください" },
+        { error: "ファイルサイズは10MB以下にしてください" },
         { status: 400 }
       );
     }
 
-    // MIMEタイプチェック（クライアント報告値）
-    if (!ALLOWED_TYPES[file.type]) {
+    // MIMEタイプチェック（クライアント報告値が空/不正な場合は拡張子から推定し、実体はマジックバイトで確認）
+    const reportedMimeType = normalizeMimeType(file.type);
+    const inferredMimeType = inferMimeTypeFromFileName(file.name);
+    const mimeType = ALLOWED_TYPES[reportedMimeType] ? reportedMimeType : inferredMimeType;
+
+    if (!mimeType || !ALLOWED_TYPES[mimeType]) {
       return NextResponse.json(
         { error: "許可されていないファイル形式です（JPEG, PNG, GIF, WebPのみ）" },
         { status: 400 }
@@ -89,7 +112,7 @@ export async function POST(req: Request) {
     const buffer = Buffer.from(bytes);
 
     // マジックバイトによる実際のファイル形式検証
-    if (!validateMagicBytes(buffer, file.type)) {
+    if (!validateMagicBytes(buffer, mimeType)) {
       return NextResponse.json(
         { error: "ファイルの内容が不正です" },
         { status: 400 }
@@ -101,7 +124,7 @@ export async function POST(req: Request) {
     await mkdir(uploadDir, { recursive: true });
 
     // ランダムファイル名を生成（MIMEタイプに基づく安全な拡張子を使用）
-    const ext = ALLOWED_TYPES[file.type];
+    const ext = ALLOWED_TYPES[mimeType];
     const randomName = crypto.randomUUID();
     const fileName = `${randomName}${ext}`;
     const filePath = path.join(uploadDir, fileName);
@@ -109,7 +132,8 @@ export async function POST(req: Request) {
 
     const imageUrl = `/uploads/${fileName}`;
     return NextResponse.json({ url: imageUrl });
-  } catch {
+  } catch (error) {
+    logger.error("アップロードエラー:", error);
     return NextResponse.json({ error: "アップロードに失敗しました" }, { status: 500 });
   }
 }

--- a/next/src/app/portal-admin/blog/edit/[id]/page.tsx
+++ b/next/src/app/portal-admin/blog/edit/[id]/page.tsx
@@ -4,6 +4,23 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import type { BlogItem } from "@/types/models";
 
+type ApiErrorResponse = {
+    error?: string;
+};
+
+type UploadResponse = {
+    url?: string;
+};
+
+async function readApiError(response: Response, fallback: string) {
+    try {
+        const data = (await response.json()) as ApiErrorResponse;
+        return data.error || fallback;
+    } catch {
+        return fallback;
+    }
+}
+
 export default function EditBlogPage() {
     const { id } = useParams();
     const router = useRouter();
@@ -36,19 +53,28 @@ export default function EditBlogPage() {
         const formData = new FormData();
         formData.append("file", file);
 
-        const res = await fetch("/api/admin/upload", {
-            method: "POST",
-            body: formData,
-        });
+        try {
+            const res = await fetch("/api/admin/upload", {
+                method: "POST",
+                body: formData,
+            });
 
-        const data = await res.json();
-        if (res.ok) {
-            setImageUrl(data.url);
-        } else {
-            alert("画像アップロードに失敗しました");
+            if (!res.ok) {
+                alert(await readApiError(res, "画像アップロードに失敗しました"));
+                return;
+            }
+
+            const data = (await res.json()) as UploadResponse;
+            if (data.url) {
+                setImageUrl(data.url);
+            } else {
+                alert("アップロード結果のURLが取得できませんでした");
+            }
+        } catch {
+            alert("画像アップロード中にエラーが発生しました");
+        } finally {
+            setUploading(false);
         }
-
-        setUploading(false);
     };
 
     const handleUpdate = async (e: React.FormEvent) => {
@@ -59,7 +85,7 @@ export default function EditBlogPage() {
             body: JSON.stringify({ title, content, imageUrl, imagePosition }),
         });
         if (res.ok) router.push("/portal-admin/blog");
-        else alert("更新に失敗しました");
+        else alert(await readApiError(res, "更新に失敗しました"));
     };
 
     return (

--- a/next/src/app/portal-admin/blog/new/page.tsx
+++ b/next/src/app/portal-admin/blog/new/page.tsx
@@ -1,7 +1,20 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+type ApiErrorResponse = {
+    error?: string;
+};
+
+async function readApiError(response: Response, fallback: string) {
+    try {
+        const data = (await response.json()) as ApiErrorResponse;
+        return data.error || fallback;
+    } catch {
+        return fallback;
+    }
+}
 
 export default function NewBlogPage() {
     const router = useRouter();
@@ -13,13 +26,20 @@ export default function NewBlogPage() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
 
+    useEffect(() => {
+        return () => {
+            if (previewUrl) {
+                URL.revokeObjectURL(previewUrl);
+            }
+        };
+    }, [previewUrl]);
+
     // 📸 プレビュー表示
     const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (file) {
-            setImageFile(file);
-            setPreviewUrl(URL.createObjectURL(file));
-        }
+        const file = e.target.files?.[0] ?? null;
+        setError("");
+        setImageFile(file);
+        setPreviewUrl(file ? URL.createObjectURL(file) : null);
     };
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -41,7 +61,7 @@ export default function NewBlogPage() {
                 });
 
                 if (!uploadRes.ok) {
-                    throw new Error("画像のアップロードに失敗しました");
+                    throw new Error(await readApiError(uploadRes, "画像のアップロードに失敗しました"));
                 }
 
                 const uploadData = await uploadRes.json();
@@ -56,8 +76,7 @@ export default function NewBlogPage() {
             });
 
             if (!res.ok) {
-                const err = await res.json();
-                throw new Error(err.error || "投稿に失敗しました");
+                throw new Error(await readApiError(res, "投稿に失敗しました"));
             }
 
             router.push("/portal-admin/blog");

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -32,7 +32,7 @@ server {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://static.wixstatic.com; frame-src https://www.google.com; connect-src 'self' https://www.google.com;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://static.wixstatic.com; frame-src https://www.google.com; connect-src 'self' https://www.google.com;" always;
 
     client_max_body_size 10M;
 


### PR DESCRIPTION
## Summary
- Allow blob: image sources in the nginx CSP so local file previews render in the haiku admin form.
- Surface upload/update API error messages in the haiku new/edit screens instead of replacing them with generic alerts.
- Make image upload handling more tolerant of common JPEG MIME variants while still validating file signatures, and align the upload limit with nginx's 10MB request limit.
- Log unexpected upload failures server-side for easier production diagnosis.

## Root Cause
After the production deploy, nginx's CSP blocked blob: URLs created by URL.createObjectURL, so selected image previews could not render. The upload path also hid useful API errors, which made permission and validation failures harder to diagnose.

## Validation
- npm run lint (passes with existing warnings)
- npx tsc --noEmit
- git diff --check